### PR TITLE
Update to v0.0.11

### DIFF
--- a/io.github.mak448a.QTCord.yml
+++ b/io.github.mak448a.QTCord.yml
@@ -23,5 +23,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/mak448a/QTCord
-        tag: v0.0.10
-        commit: 2341ce1a28bf429fe652d5058c3732b896c40ce4
+        tag: v0.0.11
+        commit: e2f1970408b570ce91caa71b1958a9fa29ebba10


### PR DESCRIPTION
v0.0.11 makes the icon a little smaller to not look too huge on docks, and adds a license ui, instead of the button leading to nothing.